### PR TITLE
Blunt workaround for audio autoplay block

### DIFF
--- a/js_david/main.js
+++ b/js_david/main.js
@@ -188,6 +188,14 @@ const playNewSong = () => {
     currentSong = new Audio(newSong);
     currentSong.play().catch(err => {
         console.log(`Could not start song (Error: ${err})`);
+          const workaround = () => {
+              new Audio(songRetriever.retrieve()).play()
+                .then(() => document.removeEventListener('keydown', workaround))
+                .catch(err => {
+                  console.error(`Tried again, still can't start song (Error: ${err})`);
+              });
+          };
+        document.addEventListener('keydown', workaround);
     });
     currentSong.addEventListener("ended", playNewSong);
 };


### PR DESCRIPTION
In Chromium v72, audio cannot be played automatically by JavaScript before the user interacts with the page.


> NotAllowedError: play() failed because the user didn't interact with the document first. https://goo.gl/xX8pDD

The web app is really creepy without the wubs so I suggest this patch as a temporary hotfix. (In the future, perhaps a modal should appear first that also displays instructions.)